### PR TITLE
修复评论检查对 12006 的错误提示

### DIFF
--- a/biliSendCommAntifraud/app/src/main/java/icu/freedomIntrovert/biliSendCommAntifraud/async/commentcheck/CommentCheckTask.java
+++ b/biliSendCommAntifraud/app/src/main/java/icu/freedomIntrovert/biliSendCommAntifraud/async/commentcheck/CommentCheckTask.java
@@ -166,7 +166,7 @@ public class CommentCheckTask extends CommentOperateTask<CommentCheckTask.EventH
                         historyComment.setFirstStateAndCurrentState(HistoryComment.STATE_UNDER_REVIEW);
                         return historyComment;
                     }
-                } else if (noACResp.code == GeneralResponse.CODE_COMMENT_DELETED) {
+                } else if (GeneralResponse.isCommentUnavailable(noACResp.code)) {
                     //评论shadowBan
                     historyComment.setFirstStateAndCurrentState(HistoryComment.STATE_SHADOW_BAN);
                     return historyComment;

--- a/biliSendCommAntifraud/app/src/main/java/icu/freedomIntrovert/biliSendCommAntifraud/biliApis/GeneralResponse.java
+++ b/biliSendCommAntifraud/app/src/main/java/icu/freedomIntrovert/biliSendCommAntifraud/biliApis/GeneralResponse.java
@@ -7,4 +7,9 @@ public class GeneralResponse<T> extends BaseResponse {
     public static final int CODE_COMMENT_NOT_THIS = 12006;
     public static final int CODE_COMMENT_AREA_CLOSED = 12002;
     public T data;
+
+    /** Reply APIs use both codes when an anonymous caller cannot see a comment. */
+    public static boolean isCommentUnavailable(int code) {
+        return code == CODE_COMMENT_DELETED || code == CODE_COMMENT_NOT_THIS;
+    }
 }

--- a/biliSendCommAntifraud/app/src/main/java/icu/freedomIntrovert/biliSendCommAntifraud/comment/CommentManipulator.java
+++ b/biliSendCommAntifraud/app/src/main/java/icu/freedomIntrovert/biliSendCommAntifraud/comment/CommentManipulator.java
@@ -552,7 +552,7 @@ public class CommentManipulator {
                         return updateHistoryComment(foundComment, HistoryComment.STATE_NORMAL, historyComment);
                     }
                 }
-            } else if (grN.code == GeneralResponse.CODE_COMMENT_DELETED) {
+            } else if (GeneralResponse.isCommentUnavailable(grN.code)) {
                 return updateHistoryComment(rootComment, HistoryComment.STATE_SHADOW_BAN, historyComment);
             } else {
                 throw new BiliBiliApiException(grN, "无账号获取评论回复页失败");
@@ -591,7 +591,7 @@ public class CommentManipulator {
                     return updateHistoryComment(null, HistoryComment.STATE_DELETED, historyComment);
                 }
             }
-        } else if (gr.code == GeneralResponse.CODE_COMMENT_DELETED) {//根评论挂了
+        } else if (GeneralResponse.isCommentUnavailable(gr.code)) {//根评论挂了
             throw new RootCommentDeadException(historyComment.root, gr);
         } else if (gr.code == GeneralResponse.CODE_COMMENT_AREA_CLOSED) {
             return null;

--- a/biliSendCommAntifraud/app/src/test/java/icu/freedomIntrovert/biliSendCommAntifraud/biliApis/GeneralResponseTest.java
+++ b/biliSendCommAntifraud/app/src/test/java/icu/freedomIntrovert/biliSendCommAntifraud/biliApis/GeneralResponseTest.java
@@ -1,0 +1,20 @@
+package icu.freedomIntrovert.biliSendCommAntifraud.biliApis;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GeneralResponseTest {
+    @Test
+    public void commentUnavailableIncludesDeletedAndNotThis() {
+        assertTrue(GeneralResponse.isCommentUnavailable(GeneralResponse.CODE_COMMENT_DELETED));
+        assertTrue(GeneralResponse.isCommentUnavailable(GeneralResponse.CODE_COMMENT_NOT_THIS));
+    }
+
+    @Test
+    public void unrelatedCodesAreNotCommentUnavailable() {
+        assertFalse(GeneralResponse.isCommentUnavailable(GeneralResponse.CODE_SUCCESS));
+        assertFalse(GeneralResponse.isCommentUnavailable(GeneralResponse.CODE_COMMENT_CONTAIN_SENSITIVE));
+    }
+}


### PR DESCRIPTION
## 问题

部分评论检查时，登录账号可以获取评论，但匿名查询 `/x/v2/reply/reply` 返回 `code=12006`（没有该评论）。原逻辑只识别 `12022`，因此把可判定的不可见评论错误地弹成 API 错误。

## 修复

- 新增 `GeneralResponse.isCommentUnavailable()`，统一识别 `12022` 和 `12006`。
- 普通评论检查：`12006` 进入现有 ShadowBan 判定。
- 历史根评论、楼中楼复查：同样按不可见评论处理。
- 增加错误码回归测试。

## 验证

- 基于上游当前 `main`，包含 `1de5ae1`、`8d8b31e`。
- `clean :app:testDebugUnitTest`：29 tests / 0 failures。
- 本地设备已验证修复有效。
